### PR TITLE
chore(pkg): declare top-level "svelte" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"url": "https://github.com/stickerdaniel/convex-autumn-svelte/issues"
 	},
 	"type": "module",
+	"svelte": "./dist/svelte/index.svelte.js",
 	"engines": {
 		"node": ">=18.0.0"
 	},


### PR DESCRIPTION
## Summary

Declares a top-level `"svelte"` field in `package.json` so SvelteKit auto-adds the package to `ssr.noExternal` and bundles it with the consumer's svelte instance during SSR.

Without this, the package is externalized at runtime and its `import { setContext } from 'svelte'` resolves to a separate svelte module from the consumer's compiled chunks. Module-scoped `ssr_context` is split between the two copies, so any context API call (here via `setupConvex` -> `setConvexClientContext`) throws `lifecycle_outside_component` during prerender even though the call is inside a `$$renderer.component()` callback.

Path mirrors the existing `./svelte` export entry: `./dist/svelte/index.svelte.js`.

Resolves: #29

## References

- SvelteKit auto-bundling Svelte component libraries: https://github.com/sveltejs/kit/pull/1148
- Auto-detect via `svelte` field: https://github.com/sveltejs/kit/issues/904
- Vite `ssr.noExternal` docs: https://vite.dev/config/ssr-options.html#ssr-noexternal

## Test plan

- [ ] CI green
- [ ] After publish, consumer can drop `'@stickerdaniel/convex-autumn-svelte'` from `ssr.noExternal` in their `vite.config.ts` without prerender regressions