### PR TITLE
fix(pkg): declare svelte field and root export for SSR auto-bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"url": "https://github.com/stickerdaniel/convex-autumn-svelte/issues"
 	},
 	"type": "module",
+	"svelte": "./dist/svelte/index.svelte.js",
 	"engines": {
 		"node": ">=18.0.0"
 	},
@@ -65,6 +66,11 @@
 		"test:unit": "vitest run tests/unit"
 	},
 	"exports": {
+		".": {
+			"types": "./dist/svelte/index.svelte.d.ts",
+			"svelte": "./dist/svelte/index.svelte.js",
+			"default": "./dist/svelte/index.svelte.js"
+		},
 		"./svelte": {
 			"types": "./dist/svelte/index.svelte.d.ts",
 			"svelte": "./dist/svelte/index.svelte.js",


### PR DESCRIPTION
## Summary

- Add top-level `"svelte": "./dist/svelte/index.svelte.js"` field so SvelteKit's `crawlFrameworkPkgs` auto-adds the package to `ssr.noExternal`.
- Add `"."` root export aligned with the `svelte` field to keep bundler resolution consistent (resolves the `@sveltejs/package` warning).

Without the `svelte` field, SvelteKit externalizes this package during SSR. `setupAutumn` calls `useConvexClient` which calls `getContext` against a separate Svelte instance from the consumer's bundle, surfacing as `lifecycle_outside_component` during prerender. Consumers were forced to set `ssr.noExternal: ['@stickerdaniel/convex-autumn-svelte']` manually.

## Test plan

- [x] `bun run package` — `publint`: All good, no `@sveltejs/package` warnings
- [x] Existing subpath imports (`/svelte`, `/sveltekit`, `/sveltekit/server`) unchanged
- [ ] Verify in saas-starter that the manual `ssr.noExternal` workaround can be dropped (follow-up after #31)

Closes #29