### PR TITLE
feat(pkg)!: migrate convex-svelte peer to @mmailaender/convex-svelte

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@convex-dev/auth": "0.0.90",
         "@mmailaender/convex-auth-svelte": "0.1.3",
+        "@mmailaender/convex-svelte": "0.19.0",
         "@playwright/test": "1.58.2",
         "@skeletonlabs/skeleton": "4.13.0",
         "@skeletonlabs/skeleton-svelte": "4.13.0",
@@ -31,7 +32,7 @@
         "@types/node": "25.5.0",
         "concurrently": "9.2.1",
         "convex": "1.33.1",
-        "convex-svelte": "0.0.12",
+        "convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0",
         "dotenv": "17.3.1",
         "jose": "6.2.2",
         "prettier": "3.8.1",
@@ -48,7 +49,6 @@
       "peerDependencies": {
         "@sveltejs/kit": "^2.21.0",
         "convex": "^1.24.3",
-        "convex-svelte": "^0.0.11 || ^0.0.12",
         "svelte": "^5.38.5",
       },
     },
@@ -169,6 +169,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mmailaender/convex-auth-svelte": ["@mmailaender/convex-auth-svelte@0.1.3", "", { "dependencies": { "cookie": "^1.0.2", "is-network-error": "^1.3.0", "jwt-decode": "^4.0.0", "path-to-regexp": "^8.3.0" }, "peerDependencies": { "@auth/core": "^0.37.0", "@convex-dev/auth": "^0.0.87", "@sveltejs/kit": "^2.21.0", "convex": "^1.24.3", "convex-svelte": "^0.0.12", "svelte": "^5.38.5" } }, "sha512-Z28iu7z5ueFNdPcoZF/j90IFDOE6K5QypZva/OWf1jA+0p44iS8EpN+XPtIRd1KD+B33m7HQ7Zdfvo40CFYAjA=="],
+
+    "@mmailaender/convex-svelte": ["@mmailaender/convex-svelte@0.19.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": ">1.10.0", "svelte": ">=5.36.0" } }, "sha512-fhzhRwIK2YYjeZmSQZgSPB4zO31HzS6NNUxwptivVNJpjeZshE8/nwJs4k6NVe9eICi2GGY04ILmZpO1I2aaXQ=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 
@@ -492,7 +494,7 @@
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
 
-    "convex-svelte": ["convex-svelte@0.0.12", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.31.1" }, "peerDependencies": { "convex": "^1.10.0", "svelte": "^5.0.0" } }, "sha512-sUZoYp4ZsokyvKlbbg1dWYB7MkAjZn4nNG9DnADEt9L6KTKuhhnEIt6fdLj+3GnVBUGDTssm17+7ppzFc4y7Gg=="],
+    "convex-svelte": ["@mmailaender/convex-svelte@0.19.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": ">1.10.0", "svelte": ">=5.36.0" } }, "sha512-fhzhRwIK2YYjeZmSQZgSPB4zO31HzS6NNUxwptivVNJpjeZshE8/nwJs4k6NVe9eICi2GGY04ILmZpO1I2aaXQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -732,7 +734,7 @@
 
     "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
 
-    "runed": ["runed@0.31.1", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-v3czcTnO+EJjiPvD4dwIqfTdHLZ8oH0zJheKqAHh9QMViY7Qb29UlAMRpX7ZtHh7AFqV60KmfxaJ9QMy+L1igQ=="],
+    "runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 	"devDependencies": {
 		"@convex-dev/auth": "0.0.90",
 		"@mmailaender/convex-auth-svelte": "0.1.3",
+		"@mmailaender/convex-svelte": "0.19.0",
 		"@playwright/test": "1.58.2",
 		"@skeletonlabs/skeleton": "4.13.0",
 		"@skeletonlabs/skeleton-svelte": "4.13.0",
@@ -104,7 +105,7 @@
 		"@types/node": "25.5.0",
 		"concurrently": "9.2.1",
 		"convex": "1.33.1",
-		"convex-svelte": "0.0.12",
+		"convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0",
 		"dotenv": "17.3.1",
 		"jose": "6.2.2",
 		"prettier": "3.8.1",
@@ -119,9 +120,9 @@
 		"vitest": "4.1.0"
 	},
 	"peerDependencies": {
+		"@mmailaender/convex-svelte": "^0.18.0 || ^0.19.0",
 		"@sveltejs/kit": "^2.21.0",
 		"convex": "^1.24.3",
-		"convex-svelte": "^0.0.11 || ^0.0.12",
 		"svelte": "^5.38.5"
 	},
 	"dependencies": {

--- a/src/lib/demo/Chat/Chat.svelte
+++ b/src/lib/demo/Chat/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useQuery, useConvexClient } from 'convex-svelte';
+	import { useQuery, useConvexClient } from '@mmailaender/convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
 	import type { Id } from '$lib/convex/_generated/dataModel';
 	import Message from './Message.svelte';

--- a/src/lib/e2e/AutumnHarness.svelte
+++ b/src/lib/e2e/AutumnHarness.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
 	import { tick } from "svelte";
-	import { useConvexClient } from "convex-svelte";
+	import { useConvexClient } from "@mmailaender/convex-svelte";
 
 	import { api } from "$lib/convex/_generated/api";
 	import { normalizeCustomer } from "./normalize";

--- a/src/lib/svelte/README.md
+++ b/src/lib/svelte/README.md
@@ -129,7 +129,7 @@ export const autumn = new Autumn(components.autumn, {
 ## Installation
 
 ```bash
-bun add @stickerdaniel/convex-autumn-svelte convex convex-svelte
+bun add @stickerdaniel/convex-autumn-svelte convex @mmailaender/convex-svelte
 ```
 
 ## Setup
@@ -178,7 +178,7 @@ export const {
 ```svelte
 <!-- App.svelte or +layout.svelte -->
 <script lang="ts">
-  import { setupConvex } from 'convex-svelte';
+  import { setupConvex } from '@mmailaender/convex-svelte';
   import { setupAutumn } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from './convex/_generated/api';
   import { PUBLIC_CONVEX_URL } from '$env/static/public';
@@ -448,7 +448,7 @@ export const send = action({
 
 ```svelte
 <script lang="ts">
-  import { useConvexClient } from 'convex-svelte';
+  import { useConvexClient } from '@mmailaender/convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from './convex/_generated/api';
 
@@ -519,7 +519,7 @@ export const send = action({
 ```svelte
 <!-- src/lib/demo/Chat/Chat.svelte - Client component -->
 <script lang="ts">
-  import { useConvexClient } from 'convex-svelte';
+  import { useConvexClient } from '@mmailaender/convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from '$lib/convex/_generated/api';
 

--- a/src/lib/svelte/client.svelte.ts
+++ b/src/lib/svelte/client.svelte.ts
@@ -6,7 +6,7 @@
  */
 
 import { getContext, setContext } from "svelte";
-import { useConvexClient } from "convex-svelte";
+import { useConvexClient } from "@mmailaender/convex-svelte";
 
 import type {
 	AutumnConvexApi,

--- a/src/lib/sveltekit/README.md
+++ b/src/lib/sveltekit/README.md
@@ -229,8 +229,17 @@ The `identify` function in your `convex/autumn.ts` receives the authenticated co
 ## Installation
 
 ```bash
-bun add @stickerdaniel/convex-autumn-svelte
+bun add @stickerdaniel/convex-autumn-svelte convex @mmailaender/convex-svelte
 ```
+
+> **Using `@mmailaender/convex-auth-svelte` (≤ 0.1.3) alongside this package?**
+> The auth wrapper has a static `import from "convex-svelte"` (the unscoped name) in its dist output. Until that is fixed upstream, add this alias to your own `package.json` so module resolution succeeds:
+>
+> ```jsonc
+> "convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0"
+> ```
+>
+> Without the alias the build fails before SSR even runs — `ssr.noExternal` cannot substitute, it only changes bundling. If a duplicate Svelte instance still surfaces during SSR after the alias is in place, additionally set `ssr.noExternal: ['@mmailaender/convex-auth-svelte']` in `vite.config.ts`. This package itself no longer needs either workaround.
 
 ## Setup
 
@@ -314,7 +323,7 @@ Initialize Autumn in your layout component with server state and pass the `inval
 ```svelte
 <!-- src/routes/+layout.svelte -->
 <script lang="ts">
-  import { setupConvex } from 'convex-svelte';
+  import { setupConvex } from '@mmailaender/convex-svelte';
   import { setupAutumn } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { invalidate } from '$app/navigation';
   import { api } from '$lib/convex/_generated/api';
@@ -498,7 +507,7 @@ export const send = action({
 
 ```svelte
 <script lang="ts">
-  import { useConvexClient } from 'convex-svelte';
+  import { useConvexClient } from '@mmailaender/convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { api } from '$lib/convex/_generated/api';
 
@@ -584,7 +593,7 @@ export const send = action({
 ```svelte
 <!-- src/lib/demo/Chat/Chat.svelte - SvelteKit component -->
 <script lang="ts">
-  import { useConvexClient } from 'convex-svelte';
+  import { useConvexClient } from '@mmailaender/convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { api } from '$lib/convex/_generated/api';
 

--- a/src/lib/sveltekit/client.svelte.ts
+++ b/src/lib/sveltekit/client.svelte.ts
@@ -5,7 +5,7 @@
  */
 
 import { getContext, setContext } from "svelte";
-import { useConvexClient } from "convex-svelte";
+import { useConvexClient } from "@mmailaender/convex-svelte";
 
 import type {
 	AutumnConvexApi,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setupConvex } from 'convex-svelte';
+	import { setupConvex } from '@mmailaender/convex-svelte';
 	import { setupConvexAuth } from '@mmailaender/convex-auth-svelte/sveltekit';
 	import { setupAutumn } from '$lib/sveltekit';
 	import { invalidate } from '$app/navigation';

--- a/src/routes/__e2e/svelte/+page.svelte
+++ b/src/routes/__e2e/svelte/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy } from "svelte";
 	import { page } from "$app/state";
-	import { useConvexClient } from "convex-svelte";
+	import { useConvexClient } from "@mmailaender/convex-svelte";
 
 	import AutumnHarness from "$lib/e2e/AutumnHarness.svelte";
 	import { api } from "$lib/convex/_generated/api";

--- a/src/routes/product/+page.svelte
+++ b/src/routes/product/+page.svelte
@@ -3,7 +3,7 @@
 	import Chat from '$lib/demo/Chat/Chat.svelte';
 	import ChatIntro from '$lib/demo/Chat/ChatIntro.svelte';
 	import UserMenu from '$lib/demo/UserMenu.svelte';
-	import { useQuery } from 'convex-svelte';
+	import { useQuery } from '@mmailaender/convex-svelte';
 	import { useCustomer } from '$lib/sveltekit';
 
 	let { data } = $props();

--- a/tests/unit/svelte-client.test.ts
+++ b/tests/unit/svelte-client.test.ts
@@ -28,7 +28,7 @@ vi.mock("svelte", () => ({
 	},
 }));
 
-vi.mock("convex-svelte", () => ({
+vi.mock("@mmailaender/convex-svelte", () => ({
 	useConvexClient: () => testState.convexClient,
 }));
 

--- a/tests/unit/sveltekit-client.test.ts
+++ b/tests/unit/sveltekit-client.test.ts
@@ -28,7 +28,7 @@ vi.mock("svelte", () => ({
 	},
 }));
 
-vi.mock("convex-svelte", () => ({
+vi.mock("@mmailaender/convex-svelte", () => ({
 	useConvexClient: () => testState.convexClient,
 }));
 


### PR DESCRIPTION
Closes #31. See also #29.

Issue #29 (PR #32) declared the `svelte` field so SvelteKit's `crawlFrameworkPkgs` can auto-`noExternal` this package, but consumers were still forced to alias `convex-svelte` to `@mmailaender/convex-svelte` and add `ssr.noExternal` because the lib itself kept importing from the unscoped package name. The alias never matches the canonical `svelte` field, so a second Svelte instance leaked into SSR and broke prerender with `lifecycle_outside_component`.

This PR switches the peer dependency and every source import to `@mmailaender/convex-svelte` directly. The README install snippets and hook examples follow. Test mocks switch from `vi.mock("convex-svelte", …)` to the scoped name so they keep matching the real import path. `dist/` regenerates with `from "@mmailaender/convex-svelte"` end to end.

`@mmailaender/convex-auth-svelte` 0.1.3 itself still has a static `import from "convex-svelte"` in its dist output, so consumers stacking both packages must keep an `npm:@mmailaender/convex-svelte` alias entry for the unscoped specifier — otherwise module resolution fails before SSR even runs. `ssr.noExternal` alone does not substitute for the alias since it only flips bundling, not resolution. The SvelteKit README documents this caveat with a copy-paste fix. This repo adds the same alias as a devDependency so the demo and E2E routes that use `setupConvexAuth` keep building.

Breaking for consumers: `bun add @mmailaender/convex-svelte` (or replace any existing alias).

`bun run check`, `bun run test` (4 contracts + 57 unit), and `bun run package` (incl. publint) all pass. `bun run test:e2e:smoke` passes the two SSR-relevant smokes (`server-handlers @smoke unauth`, `sveltekit-wrapper @smoke SSR hydration`); `svelte-wrapper:12 fetch-count` is a pre-existing flake unrelated to this change.