### PR TITLE
chore(release): bump to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@stickerdaniel/convex-autumn-svelte",
 	"author": "Daniel Sticker",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"description": "Svelte 5 wrapper for Convex Autumn billing - reactive, type-safe, SSR-ready",
 	"license": "MIT",
 	"keywords": [


### PR DESCRIPTION
Bump to 0.2.0 to publish #32 (`svelte` field for SSR auto-bundling) and #34 (peerDep migration to `@mmailaender/convex-svelte`). Both are install/SSR-facing changes for consumers, so a minor bump is correct under pre-1.0 semver conventions.

After merge: tag `v0.2.0`, push tag, run `bun run package`, `npm publish`. Unblocks `stickerdaniel/saas-starter#359`.