### PR TITLE
feat(pkg)!: migrate convex-svelte peer to official package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
       "devDependencies": {
         "@convex-dev/auth": "0.0.90",
         "@mmailaender/convex-auth-svelte": "0.1.3",
-        "@mmailaender/convex-svelte": "0.19.0",
         "@playwright/test": "1.58.2",
         "@skeletonlabs/skeleton": "4.13.0",
         "@skeletonlabs/skeleton-svelte": "4.13.0",
@@ -32,7 +31,7 @@
         "@types/node": "25.5.0",
         "concurrently": "9.2.1",
         "convex": "1.33.1",
-        "convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0",
+        "convex-svelte": "0.14.0",
         "dotenv": "17.3.1",
         "jose": "6.2.2",
         "prettier": "3.8.1",
@@ -169,8 +168,6 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mmailaender/convex-auth-svelte": ["@mmailaender/convex-auth-svelte@0.1.3", "", { "dependencies": { "cookie": "^1.0.2", "is-network-error": "^1.3.0", "jwt-decode": "^4.0.0", "path-to-regexp": "^8.3.0" }, "peerDependencies": { "@auth/core": "^0.37.0", "@convex-dev/auth": "^0.0.87", "@sveltejs/kit": "^2.21.0", "convex": "^1.24.3", "convex-svelte": "^0.0.12", "svelte": "^5.38.5" } }, "sha512-Z28iu7z5ueFNdPcoZF/j90IFDOE6K5QypZva/OWf1jA+0p44iS8EpN+XPtIRd1KD+B33m7HQ7Zdfvo40CFYAjA=="],
-
-    "@mmailaender/convex-svelte": ["@mmailaender/convex-svelte@0.19.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": ">1.10.0", "svelte": ">=5.36.0" } }, "sha512-fhzhRwIK2YYjeZmSQZgSPB4zO31HzS6NNUxwptivVNJpjeZshE8/nwJs4k6NVe9eICi2GGY04ILmZpO1I2aaXQ=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 
@@ -494,7 +491,7 @@
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
 
-    "convex-svelte": ["@mmailaender/convex-svelte@0.19.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": ">1.10.0", "svelte": ">=5.36.0" } }, "sha512-fhzhRwIK2YYjeZmSQZgSPB4zO31HzS6NNUxwptivVNJpjeZshE8/nwJs4k6NVe9eICi2GGY04ILmZpO1I2aaXQ=="],
+    "convex-svelte": ["convex-svelte@0.14.0", "", { "dependencies": { "esm-env": "^1.2.2", "runed": "^0.37.1" }, "peerDependencies": { "convex": "^1.30.0", "svelte": "^5.19.0" } }, "sha512-eCaId++XnczQvEGc0sQi30BHkSEQ5AZjdDWaAqSlva2h9zKezGz8enp6MdFN7MIIMIlYZF3dKdzQ/LQ0d59KhQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
 	"devDependencies": {
 		"@convex-dev/auth": "0.0.90",
 		"@mmailaender/convex-auth-svelte": "0.1.3",
-		"@mmailaender/convex-svelte": "0.19.0",
 		"@playwright/test": "1.58.2",
 		"@skeletonlabs/skeleton": "4.13.0",
 		"@skeletonlabs/skeleton-svelte": "4.13.0",
@@ -105,7 +104,7 @@
 		"@types/node": "25.5.0",
 		"concurrently": "9.2.1",
 		"convex": "1.33.1",
-		"convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0",
+		"convex-svelte": "0.14.0",
 		"dotenv": "17.3.1",
 		"jose": "6.2.2",
 		"prettier": "3.8.1",
@@ -120,9 +119,9 @@
 		"vitest": "4.1.0"
 	},
 	"peerDependencies": {
-		"@mmailaender/convex-svelte": "^0.18.0 || ^0.19.0",
 		"@sveltejs/kit": "^2.21.0",
 		"convex": "^1.24.3",
+		"convex-svelte": ">=0.13.0",
 		"svelte": "^5.38.5"
 	},
 	"dependencies": {

--- a/src/lib/demo/Chat/Chat.svelte
+++ b/src/lib/demo/Chat/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { useQuery, useConvexClient } from '@mmailaender/convex-svelte';
+	import { useQuery, useConvexClient } from 'convex-svelte';
 	import { api } from '$lib/convex/_generated/api';
 	import type { Id } from '$lib/convex/_generated/dataModel';
 	import Message from './Message.svelte';

--- a/src/lib/e2e/AutumnHarness.svelte
+++ b/src/lib/e2e/AutumnHarness.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy, onMount } from "svelte";
 	import { tick } from "svelte";
-	import { useConvexClient } from "@mmailaender/convex-svelte";
+	import { useConvexClient } from "convex-svelte";
 
 	import { api } from "$lib/convex/_generated/api";
 	import { normalizeCustomer } from "./normalize";

--- a/src/lib/svelte/README.md
+++ b/src/lib/svelte/README.md
@@ -129,7 +129,7 @@ export const autumn = new Autumn(components.autumn, {
 ## Installation
 
 ```bash
-bun add @stickerdaniel/convex-autumn-svelte convex @mmailaender/convex-svelte
+bun add @stickerdaniel/convex-autumn-svelte convex convex-svelte
 ```
 
 ## Setup
@@ -178,7 +178,7 @@ export const {
 ```svelte
 <!-- App.svelte or +layout.svelte -->
 <script lang="ts">
-  import { setupConvex } from '@mmailaender/convex-svelte';
+  import { setupConvex } from 'convex-svelte';
   import { setupAutumn } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from './convex/_generated/api';
   import { PUBLIC_CONVEX_URL } from '$env/static/public';
@@ -448,7 +448,7 @@ export const send = action({
 
 ```svelte
 <script lang="ts">
-  import { useConvexClient } from '@mmailaender/convex-svelte';
+  import { useConvexClient } from 'convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from './convex/_generated/api';
 
@@ -519,7 +519,7 @@ export const send = action({
 ```svelte
 <!-- src/lib/demo/Chat/Chat.svelte - Client component -->
 <script lang="ts">
-  import { useConvexClient } from '@mmailaender/convex-svelte';
+  import { useConvexClient } from 'convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/svelte';
   import { api } from '$lib/convex/_generated/api';
 

--- a/src/lib/svelte/client.svelte.ts
+++ b/src/lib/svelte/client.svelte.ts
@@ -6,7 +6,7 @@
  */
 
 import { getContext, setContext } from "svelte";
-import { useConvexClient } from "@mmailaender/convex-svelte";
+import { useConvexClient } from "convex-svelte";
 
 import type {
 	AutumnConvexApi,

--- a/src/lib/sveltekit/README.md
+++ b/src/lib/sveltekit/README.md
@@ -229,17 +229,11 @@ The `identify` function in your `convex/autumn.ts` receives the authenticated co
 ## Installation
 
 ```bash
-bun add @stickerdaniel/convex-autumn-svelte convex @mmailaender/convex-svelte
+bun add @stickerdaniel/convex-autumn-svelte convex convex-svelte
 ```
 
-> **Using `@mmailaender/convex-auth-svelte` (≤ 0.1.3) alongside this package?**
-> The auth wrapper has a static `import from "convex-svelte"` (the unscoped name) in its dist output. Until that is fixed upstream, add this alias to your own `package.json` so module resolution succeeds:
->
-> ```jsonc
-> "convex-svelte": "npm:@mmailaender/convex-svelte@0.19.0"
-> ```
->
-> Without the alias the build fails before SSR even runs — `ssr.noExternal` cannot substitute, it only changes bundling. If a duplicate Svelte instance still surfaces during SSR after the alias is in place, additionally set `ssr.noExternal: ['@mmailaender/convex-auth-svelte']` in `vite.config.ts`. This package itself no longer needs either workaround.
+> **Using `@mmailaender/convex-auth-svelte` alongside this package?**
+> Both packages import the unscoped `convex-svelte`, so no alias is needed. If a duplicate Svelte instance surfaces during SSR, set `ssr.noExternal: ['@mmailaender/convex-auth-svelte']` in `vite.config.ts`.
 
 ## Setup
 
@@ -323,7 +317,7 @@ Initialize Autumn in your layout component with server state and pass the `inval
 ```svelte
 <!-- src/routes/+layout.svelte -->
 <script lang="ts">
-  import { setupConvex } from '@mmailaender/convex-svelte';
+  import { setupConvex } from 'convex-svelte';
   import { setupAutumn } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { invalidate } from '$app/navigation';
   import { api } from '$lib/convex/_generated/api';
@@ -507,7 +501,7 @@ export const send = action({
 
 ```svelte
 <script lang="ts">
-  import { useConvexClient } from '@mmailaender/convex-svelte';
+  import { useConvexClient } from 'convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { api } from '$lib/convex/_generated/api';
 
@@ -593,7 +587,7 @@ export const send = action({
 ```svelte
 <!-- src/lib/demo/Chat/Chat.svelte - SvelteKit component -->
 <script lang="ts">
-  import { useConvexClient } from '@mmailaender/convex-svelte';
+  import { useConvexClient } from 'convex-svelte';
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
   import { api } from '$lib/convex/_generated/api';
 

--- a/src/lib/sveltekit/client.svelte.ts
+++ b/src/lib/sveltekit/client.svelte.ts
@@ -5,7 +5,7 @@
  */
 
 import { getContext, setContext } from "svelte";
-import { useConvexClient } from "@mmailaender/convex-svelte";
+import { useConvexClient } from "convex-svelte";
 
 import type {
 	AutumnConvexApi,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { setupConvex } from '@mmailaender/convex-svelte';
+	import { setupConvex } from 'convex-svelte';
 	import { setupConvexAuth } from '@mmailaender/convex-auth-svelte/sveltekit';
 	import { setupAutumn } from '$lib/sveltekit';
 	import { invalidate } from '$app/navigation';

--- a/src/routes/__e2e/svelte/+page.svelte
+++ b/src/routes/__e2e/svelte/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy } from "svelte";
 	import { page } from "$app/state";
-	import { useConvexClient } from "@mmailaender/convex-svelte";
+	import { useConvexClient } from "convex-svelte";
 
 	import AutumnHarness from "$lib/e2e/AutumnHarness.svelte";
 	import { api } from "$lib/convex/_generated/api";

--- a/src/routes/product/+page.svelte
+++ b/src/routes/product/+page.svelte
@@ -3,7 +3,7 @@
 	import Chat from '$lib/demo/Chat/Chat.svelte';
 	import ChatIntro from '$lib/demo/Chat/ChatIntro.svelte';
 	import UserMenu from '$lib/demo/UserMenu.svelte';
-	import { useQuery } from '@mmailaender/convex-svelte';
+	import { useQuery } from 'convex-svelte';
 	import { useCustomer } from '$lib/sveltekit';
 
 	let { data } = $props();

--- a/tests/unit/svelte-client.test.ts
+++ b/tests/unit/svelte-client.test.ts
@@ -28,7 +28,7 @@ vi.mock("svelte", () => ({
 	},
 }));
 
-vi.mock("@mmailaender/convex-svelte", () => ({
+vi.mock("convex-svelte", () => ({
 	useConvexClient: () => testState.convexClient,
 }));
 

--- a/tests/unit/sveltekit-client.test.ts
+++ b/tests/unit/sveltekit-client.test.ts
@@ -28,7 +28,7 @@ vi.mock("svelte", () => ({
 	},
 }));
 
-vi.mock("@mmailaender/convex-svelte", () => ({
+vi.mock("convex-svelte", () => ({
 	useConvexClient: () => testState.convexClient,
 }));
 


### PR DESCRIPTION
The `@mmailaender/convex-svelte` fork this package depended on is deprecated, and its changes have been merged back into the official `convex-svelte` package. Downstream consumers (cadenza-app, saas-starter) are moving to official `convex-svelte` plus `@mmailaender/convex-better-auth-svelte` 0.8.1, whose peer is `convex-svelte >=0.13.0`. As long as this package peers and imports the scoped fork, those consumers are forced to resolve two separate `convex-svelte` module instances, which breaks SSR with a duplicate Svelte runtime.

Official `convex-svelte` 0.13+ is API-identical to the fork 0.19.x (same exports and `/sveltekit` + `/sveltekit/server` subpaths), so this switches the peer dependency to `convex-svelte >=0.13.0`, drops both the `@mmailaender/convex-svelte` devDependency and the `npm:@mmailaender/convex-svelte` alias in favor of the official package (pinned at 0.14.0 for dev), and points every source import, test mock, and README snippet at the unscoped `convex-svelte` specifier. The SvelteKit README alias caveat is gone: since both this package and `@mmailaender/convex-auth-svelte` now import the unscoped `convex-svelte`, no alias is needed.

This is the mirror image of #34, which moved the other direction. Versioning follows the same split as #34/#35: this PR leaves `version` at 0.2.0 and a separate `chore(release): bump to 0.3.0` PR bumps it before publish, matching the maintainer flow where #34 shipped unbumped and #35 did the release bump. A minor bump is correct under pre-1.0 semver since this is an install/peer-facing breaking change.

`bun run check` (0 errors, 16 files), `bun run test` (4 contracts + 57 unit) and `bun run package` (svelte-package + publint, "All good!") all pass; the built `dist/` imports only the unscoped official `convex-svelte`. The `d.ts` inference warnings from `svelte-package` are pre-existing, come from `@useautumn/convex` typing in the excluded `src/lib/convex` backend files, and are unrelated to this change. The live-Autumn E2E needs preview credentials and was not run locally.

See also: #34