### PR TITLE
chore(release): bump to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@stickerdaniel/convex-autumn-svelte",
 	"author": "Daniel Sticker",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Svelte 5 wrapper for Convex Autumn billing - reactive, type-safe, SSR-ready",
 	"license": "MIT",
 	"keywords": [


### PR DESCRIPTION
Release for the official convex-svelte migration (#36): the peer moved from the deprecated @mmailaender/convex-svelte fork to convex-svelte >=0.13.0, a breaking peer change on the 0.x line.

See also: #36

bun run check and bun run test pass on the merged main this branch sits on.