### PR TITLE
fix(client): Preserve Autumn results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@stickerdaniel/convex-autumn-svelte",
 	"author": "Daniel Sticker",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Svelte 5 wrapper for Convex Autumn billing - reactive, type-safe, SSR-ready",
 	"license": "MIT",
 	"keywords": [
@@ -62,7 +62,7 @@
 		"test:e2e": "playwright test",
 		"test:e2e:smoke": "playwright test --grep @smoke",
 		"test": "bun run test:contracts && bun run test:unit",
-		"test:contracts": "vitest run tests/contracts",
+		"test:contracts": "tsc --noEmit -p tsconfig.contracts.json && vitest run tests/contracts",
 		"test:unit": "vitest run tests/unit"
 	},
 	"exports": {

--- a/src/lib/svelte/README.md
+++ b/src/lib/svelte/README.md
@@ -287,8 +287,27 @@ For checks that consume usage or need server-side validation:
     });
 
     if (result.url) {
-      // User will be redirected to Stripe checkout
+      // Autumn wants the customer on a hosted Stripe page.
       window.location.href = result.url;
+      return;
+    }
+
+    // No URL means the purchase can be completed in place: `result` is a
+    // preview (lines, total, has_prorations, options). Show it, and on
+    // confirmation finish with attach. Skipping this branch is why an upgrade
+    // button can look like it does nothing.
+    const attachResult = await autumn.attach({
+      productId: result.product.id,
+      options: result.options.map(({ feature_id, quantity }) => ({
+        featureId: feature_id,
+        quantity
+      })),
+      successUrl: '/dashboard?upgraded=true'
+    });
+
+    if (attachResult.checkout_url) {
+      // The stored payment method could not be charged after all.
+      window.location.href = attachResult.checkout_url;
     }
   }
 </script>
@@ -352,8 +371,13 @@ For checks that consume usage or need server-side validation:
   const autumn = useCustomer();
 
   async function attachProduct(productId: string) {
-    await autumn.attach({ productId });
+    const result = await autumn.attach({ productId });
     // Customer data automatically refetched after attach
+
+    if (result.checkout_url) {
+      // Payment is still required: the stored method could not be charged.
+      window.location.href = result.checkout_url;
+    }
   }
 
   async function cancelProduct(productId: string) {
@@ -642,9 +666,9 @@ Hook to access customer data and billing operations.
 - `error: Error | null | undefined` - Error state
 - `allowed(params): LocalCheckResult` - Local access check (doesn't consume usage)
 - `check(params, options?): Promise<CheckResult>` - Server-side access check (auto-refetches customer)
-- `checkout(params, options?): Promise<{url?: string}>` - Initiate checkout flow (auto-refetches customer)
+- `checkout(params, options?): Promise<CheckoutResult>` - Initiate checkout flow; returns a hosted `url` or a preview to confirm with `attach` (auto-refetches customer)
 - `track(params, options?): Promise<TrackResult>` - Track usage (auto-refetches customer)
-- `attach(params, options?): Promise<void>` - Attach product to customer (auto-refetches customer)
+- `attach(params, options?): Promise<AttachResult>` - Attach product to customer; a `checkout_url` on the result means payment is still required (auto-refetches customer)
 - `cancel(params, options?): Promise<void>` - Cancel product subscription (auto-refetches customer)
 - `openBillingPortal(params): Promise<BillingPortalResult>` - Open Stripe portal
 - `createEntity(params, options?): Promise<Entity>` - Create new entity (auto-refetches customer)

--- a/src/lib/svelte/client.svelte.ts
+++ b/src/lib/svelte/client.svelte.ts
@@ -17,9 +17,11 @@ import type {
 	CheckParams,
 	CheckResult,
 	CheckoutParams,
+	CheckoutResult,
 	TrackParams,
 	TrackResult,
 	AttachParams,
+	AttachResult,
 	CancelParams,
 	BillingPortalParams,
 	BillingPortalResult,
@@ -158,16 +160,17 @@ export function createAutumnClient({
 	 *
 	 * @param params - Checkout parameters including productId and optional dialog handler
 	 * @param options - Options controlling data refetch behavior
-	 * @returns Promise resolving to checkout result with optional URL
+	 * @returns Promise resolving to the checkout result: a hosted Stripe `url`,
+	 *   or a purchase preview to confirm with `attach` when `url` is absent
 	 */
 	const checkout = async (
 		params: CheckoutParams,
 		options: RefetchOptions = {},
-	): Promise<{ url?: string }> => {
+	): Promise<CheckoutResult> => {
 		const { refetch = true } = options;
 
 		const result = await client.action(convexApi.checkout, params);
-		const data = unwrapAutumnResponse<{ url?: string }>(result);
+		const data = unwrapAutumnResponse<CheckoutResult>(result);
 
 		if (params.dialog && data.url) {
 			if (isBrowser) {
@@ -210,20 +213,23 @@ export function createAutumnClient({
 	 *
 	 * @param params - Attach parameters including productId
 	 * @param options - Options controlling data refetch behavior
-	 * @returns Promise that resolves when attachment completes
+	 * @returns Promise resolving to the attach result, including `checkout_url`
+	 *   when the stored payment method could not be charged
 	 */
 	const attach = async (
 		params: AttachParams,
 		options: RefetchOptions = {},
-	): Promise<void> => {
+	): Promise<AttachResult> => {
 		const { refetch = true } = options;
 
 		const result = await client.action(convexApi.attach, params);
-		unwrapAutumnResponse<void>(result);
+		const data = unwrapAutumnResponse<AttachResult>(result);
 
 		if (refetch) {
 			await fetchCustomer();
 		}
+
+		return data;
 	};
 
 	/**

--- a/src/lib/svelte/index.svelte.ts
+++ b/src/lib/svelte/index.svelte.ts
@@ -60,9 +60,9 @@ export function setupAutumn({
  * @returns {Error | null | undefined} error - Error if customer fetch failed
  * @returns {function(CheckParams): LocalCheckResult} allowed - Local check for feature access without consuming usage
  * @returns {function(CheckParams): Promise<CheckResult>} check - Server-side check with usage tracking
- * @returns {function(CheckoutParams): Promise<{url?: string}>} checkout - Initiate checkout for a product
+ * @returns {function(CheckoutParams): Promise<CheckoutResult>} checkout - Initiate checkout; returns a hosted url or a preview to confirm with attach
  * @returns {function(TrackParams): Promise<TrackResult>} track - Track usage of a feature
- * @returns {function(AttachParams): Promise<void>} attach - Attach a product to the customer
+ * @returns {function(AttachParams): Promise<AttachResult>} attach - Attach a product to the customer
  * @returns {function(CancelParams): Promise<void>} cancel - Cancel a product subscription
  * @returns {function(BillingPortalParams): Promise<BillingPortalResult>} openBillingPortal - Open Stripe billing portal
  * @returns {function(CreateEntityParams): Promise<Entity>} createEntity - Create a new entity
@@ -232,9 +232,12 @@ export type {
 	CheckParams,
 	CheckResult,
 	CheckoutParams,
+	CheckoutResult,
 	TrackParams,
 	TrackResult,
 	AttachParams,
+	AttachResult,
+	AttachFeatureOptions,
 	CancelParams,
 	BillingPortalParams,
 	BillingPortalResult,

--- a/src/lib/svelte/types.ts
+++ b/src/lib/svelte/types.ts
@@ -6,6 +6,11 @@
  */
 
 import type { FunctionReference } from "convex/server";
+import type {
+	AttachFeatureOptions as AutumnAttachFeatureOptions,
+	AttachResult as AutumnAttachResult,
+	CheckoutResult as AutumnCheckoutResult,
+} from "autumn-js";
 
 /**
  * Represents a billable feature in Autumn.
@@ -95,6 +100,32 @@ export interface CheckoutParams {
 	successUrl?: string;
 	[key: string]: unknown;
 }
+
+/**
+ * Prepaid feature quantity carried by a checkout preview.
+ */
+export type AttachFeatureOptions = AutumnAttachFeatureOptions;
+
+/**
+ * Result of initiating checkout.
+ *
+ * Autumn declares `url` as `string | undefined`, but the live API answers with
+ * `null` when the purchase can be completed in-app instead of through a hosted
+ * Stripe session. The widened type keeps that case visible: an absent URL is
+ * the documented signal to show the returned preview and confirm it with
+ * `attach`, not an error.
+ */
+export type CheckoutResult = Omit<AutumnCheckoutResult, "url"> & {
+	url?: string | null;
+};
+
+/**
+ * Result of attaching a product.
+ *
+ * `checkout_url` is set when the stored payment method could not be charged
+ * and Autumn wants the customer to complete payment on a hosted page.
+ */
+export type AttachResult = AutumnAttachResult;
 
 /**
  * Parameters for tracking usage.

--- a/src/lib/sveltekit/README.md
+++ b/src/lib/sveltekit/README.md
@@ -401,7 +401,7 @@ With SSR, your data is available immediately:
 <script lang="ts">
   import { useCustomer } from '@stickerdaniel/convex-autumn-svelte/sveltekit';
 
-  const { customer, checkout } = useCustomer();
+  const { customer, checkout, attach } = useCustomer();
 
   async function upgradeToPro() {
     const result = await checkout({
@@ -412,7 +412,27 @@ With SSR, your data is available immediately:
     // Data will automatically refresh via invalidateAll()
 
     if (result.url) {
+      // Autumn wants the customer on a hosted Stripe page.
       window.location.href = result.url;
+      return;
+    }
+
+    // No URL means the purchase can be completed in place: `result` is a
+    // preview (lines, total, has_prorations, options). Show it, and on
+    // confirmation finish with attach. Skipping this branch is why an upgrade
+    // button can look like it does nothing.
+    const attachResult = await attach({
+      productId: result.product.id,
+      options: result.options.map(({ feature_id, quantity }) => ({
+        featureId: feature_id,
+        quantity
+      })),
+      successUrl: '/dashboard?upgraded=true'
+    });
+
+    if (attachResult.checkout_url) {
+      // The stored payment method could not be charged after all.
+      window.location.href = attachResult.checkout_url;
     }
   }
 
@@ -820,9 +840,9 @@ Hook to access customer data and billing operations.
 - `customer: Customer | null` - Current customer data (reactive, hydrated from SSR)
 - `allowed(params): LocalCheckResult` - Local access check (doesn't consume usage)
 - `check(params, options?): Promise<CheckResult>` - Server-side access check (auto-invalidates)
-- `checkout(params, options?): Promise<{url?: string}>` - Initiate checkout flow (auto-invalidates)
+- `checkout(params, options?): Promise<CheckoutResult>` - Initiate checkout flow; returns a hosted `url` or a preview to confirm with `attach` (auto-invalidates)
 - `track(params, options?): Promise<TrackResult>` - Track usage (auto-invalidates)
-- `attach(params, options?): Promise<void>` - Attach product to customer (auto-invalidates)
+- `attach(params, options?): Promise<AttachResult>` - Attach product to customer; a `checkout_url` on the result means payment is still required (auto-invalidates)
 - `cancel(params, options?): Promise<void>` - Cancel product subscription (auto-invalidates)
 - `openBillingPortal(params): Promise<BillingPortalResult>` - Open Stripe portal
 - `createEntity(params, options?): Promise<Entity>` - Create new entity (auto-invalidates)
@@ -880,9 +900,14 @@ returns: {
 }
 ```
 
-**`checkout(params: CheckoutParams, options?: RefetchOptions): Promise<{url?: string}>`**
+**`checkout(params: CheckoutParams, options?: RefetchOptions): Promise<CheckoutResult>`**
 
 Initiate Stripe checkout flow.
+
+Returns the full `CheckoutResult`. When `url` is set, send the customer there.
+When it is absent (the live API answers `null`), the result is a purchase
+preview: show `lines`, `total` and `has_prorations`, then complete the purchase
+with `attach`, forwarding `options` as `{ featureId, quantity }`.
 
 ```typescript
 params: {
@@ -897,8 +922,17 @@ options: {
   refetch?: boolean;                    // Auto-invalidate (default: true)
 }
 
-returns: {
-  url?: string;                         // Stripe checkout URL
+returns: CheckoutResult {
+  url?: string | null;                  // Hosted Stripe page, absent when the
+                                        // purchase is confirmed in the app
+  product: Product;                     // What is being bought
+  current_product: Product;             // What the customer is on today
+  lines: { description: string; amount: number }[];
+  total: number;
+  currency: string;
+  has_prorations: boolean;
+  options: { feature_id: string; quantity: number }[];
+  next_cycle?: { starts_at: number; total: number };
 }
 ```
 
@@ -923,9 +957,12 @@ returns: {
 }
 ```
 
-**`attach(params: AttachParams, options?: RefetchOptions): Promise<void>`**
+**`attach(params: AttachParams, options?: RefetchOptions): Promise<AttachResult>`**
 
 Attach a product subscription to the customer.
+
+Returns the `AttachResult`. A `checkout_url` on it means the stored payment
+method could not be charged and the customer has to finish on a hosted page.
 
 ```typescript
 params: {

--- a/src/lib/sveltekit/client.svelte.ts
+++ b/src/lib/sveltekit/client.svelte.ts
@@ -14,9 +14,11 @@ import type {
 	CheckParams,
 	CheckResult,
 	CheckoutParams,
+	CheckoutResult,
 	TrackParams,
 	TrackResult,
 	AttachParams,
+	AttachResult,
 	CancelParams,
 	BillingPortalParams,
 	BillingPortalResult,
@@ -153,16 +155,17 @@ export function createAutumnClientSvelteKit({
 	 *
 	 * @param params - Checkout parameters including productId and optional dialog
 	 * @param options - Options including whether to refetch customer data
-	 * @returns Object containing the checkout URL
+	 * @returns The checkout result: a hosted Stripe `url`, or a purchase
+	 *   preview to confirm with `attach` when `url` is absent
 	 */
 	const checkout = async (
 		params: CheckoutParams,
 		options: RefetchOptions = {},
-	): Promise<{ url?: string }> => {
+	): Promise<CheckoutResult> => {
 		const { refetch = true } = options;
 
 		const result = await client.action(convexApi.checkout, params);
-		const data = unwrapAutumnResponse<{ url?: string }>(result);
+		const data = unwrapAutumnResponse<CheckoutResult>(result);
 
 		if (params.dialog && data.url) {
 			if (isBrowser) {
@@ -205,19 +208,23 @@ export function createAutumnClientSvelteKit({
 	 *
 	 * @param params - Attach parameters including productId
 	 * @param options - Options including whether to refetch customer data
+	 * @returns The attach result, including `checkout_url` when the stored
+	 *   payment method could not be charged
 	 */
 	const attach = async (
 		params: AttachParams,
 		options: RefetchOptions = {},
-	): Promise<void> => {
+	): Promise<AttachResult> => {
 		const { refetch = true } = options;
 
 		const result = await client.action(convexApi.attach, params);
-		unwrapAutumnResponse<void>(result);
+		const data = unwrapAutumnResponse<AttachResult>(result);
 
 		if (refetch && invalidate) {
 			await invalidate('autumn:customer');
 		}
+
+		return data;
 	};
 
 	/**

--- a/src/lib/sveltekit/index.ts
+++ b/src/lib/sveltekit/index.ts
@@ -96,9 +96,9 @@ export function setupAutumn({
  * @returns {Customer | null} customer - Customer data (pre-loaded via SSR, null if not found)
  * @returns {function(CheckParams): LocalCheckResult} allowed - Local check for feature access without consuming usage
  * @returns {function(CheckParams): Promise<CheckResult>} check - Server-side check with usage tracking (auto-invalidates)
- * @returns {function(CheckoutParams): Promise<{url?: string}>} checkout - Initiate checkout for a product (auto-invalidates)
+ * @returns {function(CheckoutParams): Promise<CheckoutResult>} checkout - Initiate checkout; returns a hosted url or a preview to confirm with attach (auto-invalidates)
  * @returns {function(TrackParams): Promise<TrackResult>} track - Track usage of a feature (auto-invalidates)
- * @returns {function(AttachParams): Promise<void>} attach - Attach a product to the customer (auto-invalidates)
+ * @returns {function(AttachParams): Promise<AttachResult>} attach - Attach a product to the customer (auto-invalidates)
  * @returns {function(CancelParams): Promise<void>} cancel - Cancel a product subscription (auto-invalidates)
  * @returns {function(BillingPortalParams): Promise<BillingPortalResult>} openBillingPortal - Open Stripe billing portal
  * @returns {function(CreateEntityParams): Promise<Entity>} createEntity - Create a new entity (auto-invalidates)
@@ -271,9 +271,12 @@ export type {
 	CheckParams,
 	CheckResult,
 	CheckoutParams,
+	CheckoutResult,
 	TrackParams,
 	TrackResult,
 	AttachParams,
+	AttachResult,
+	AttachFeatureOptions,
 	CancelParams,
 	BillingPortalParams,
 	BillingPortalResult,

--- a/tests/contracts/upstream-type-contract.test.ts
+++ b/tests/contracts/upstream-type-contract.test.ts
@@ -2,12 +2,20 @@ import { describe, expect, test } from "vitest";
 
 import { api } from "../../src/lib/convex/_generated/api.js";
 import type {
+	AttachResult as UpstreamAttachResult,
+	CheckoutResult as UpstreamCheckoutResult,
+} from "autumn-js";
+import type { createAutumnClient } from "../../src/lib/svelte/client.svelte.js";
+import type { createAutumnClientSvelteKit } from "../../src/lib/sveltekit/client.svelte.js";
+import type {
 	AttachParams,
+	AttachResult,
 	AutumnConvexApi,
 	BillingPortalParams,
 	CancelParams,
 	CheckParams,
 	CheckoutParams,
+	CheckoutResult,
 	CreateEntityParams,
 	CreateReferralCodeParams,
 	EventAggregateParams,
@@ -74,6 +82,39 @@ type _redeemReferralCodeParamsMatch = ExpectExtends<
 >;
 type _setUsageParamsMatch = ExpectExtends<SetUsageParams, UsageArgsType>;
 type _queryParamsMatch = ExpectExtends<QueryParams, QueryArgsType>;
+
+// Result contracts. Both results are handed back untouched, so the exported
+// types have to keep matching upstream's. The one deliberate deviation is
+// `CheckoutResult.url`: upstream declares it `string | undefined` while the
+// live API answers `null` for a purchase that needs in-app confirmation, so
+// the wrapper widens exactly that field.
+type _checkoutResultKeepsUpstreamShape = ExpectExtends<
+	Omit<CheckoutResult, "url">,
+	Omit<UpstreamCheckoutResult, "url">
+>;
+type _checkoutResultAllowsLiveNull = ExpectExtends<null, CheckoutResult["url"]>;
+type _attachResultMatchesUpstream = ExpectExtends<
+	AttachResult,
+	UpstreamAttachResult
+>;
+
+// The methods must surface those results rather than a narrowed stand-in.
+type _svelteCheckoutReturns = ExpectExtends<
+	Awaited<ReturnType<ReturnType<typeof createAutumnClient>["checkout"]>>,
+	CheckoutResult
+>;
+type _svelteAttachReturns = ExpectExtends<
+	Awaited<ReturnType<ReturnType<typeof createAutumnClient>["attach"]>>,
+	AttachResult
+>;
+type _svelteKitCheckoutReturns = ExpectExtends<
+	Awaited<ReturnType<ReturnType<typeof createAutumnClientSvelteKit>["checkout"]>>,
+	CheckoutResult
+>;
+type _svelteKitAttachReturns = ExpectExtends<
+	Awaited<ReturnType<ReturnType<typeof createAutumnClientSvelteKit>["attach"]>>,
+	AttachResult
+>;
 
 describe("upstream type contract", () => {
 	test("generated api.autumn remains assignable to AutumnConvexApi", () => {

--- a/tests/helpers/test-data.ts
+++ b/tests/helpers/test-data.ts
@@ -1,5 +1,9 @@
+import { AppEnv } from "autumn-js";
+
 import type {
+	AttachResult,
 	AutumnActionResponse,
+	CheckoutResult,
 	Customer,
 	Entity,
 	EventListResult,
@@ -77,6 +81,55 @@ export const eventListResult: EventListResult = {
 	offset: 0,
 	limit: 10,
 	total: 1,
+};
+
+const autumnProduct = (id: string, name: string) => ({
+	id,
+	name,
+	created_at: 1_735_689_600_000,
+	env: AppEnv.Sandbox,
+	is_add_on: false,
+	is_default: id === "free",
+	group: "main",
+	version: 1,
+	items: [],
+	free_trial: null,
+	base_variant_id: null,
+	properties: {
+		is_free: id === "free",
+		is_one_off: false,
+		interval_group: "month",
+		has_trial: false,
+		updateable: true,
+	},
+});
+
+/**
+ * A checkout answer that carries no hosted Stripe session.
+ *
+ * The live API returns `url: null` here, which Autumn's own declaration does
+ * not model. Consumers have to read the preview and confirm it with `attach`,
+ * so this pins the shape the wrapper must pass through untouched.
+ */
+export const checkoutPreview: CheckoutResult = {
+	url: null,
+	customer_id: "customer_free",
+	has_prorations: false,
+	lines: [{ description: "Pro - $10 / month", amount: 10, item: {} }],
+	total: 10,
+	currency: "usd",
+	options: [{ feature_id: "seats", quantity: 3 }],
+	product: autumnProduct("pro", "Pro"),
+	current_product: autumnProduct("free", "Free"),
+};
+
+/** An attach answer that still needs a hosted page to collect payment. */
+export const attachNeedsCheckout: AttachResult = {
+	customer_id: "customer_free",
+	product_ids: ["pro"],
+	code: "checkout_created",
+	message: "Payment required",
+	checkout_url: "https://checkout.test/attach",
 };
 
 export function ok<T>(data: T): AutumnActionResponse<T> {

--- a/tests/unit/svelte-client.test.ts
+++ b/tests/unit/svelte-client.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { flushPromises } from "../helpers/flush.js";
 import { mockAutumnApi } from "../helpers/mock-api.js";
 import {
+	attachNeedsCheckout,
+	checkoutPreview,
 	entity,
 	eventListResult,
 	fail,
@@ -183,6 +185,41 @@ describe("svelte client wrapper", () => {
 		);
 
 		expect(testState.convexClient.action).toHaveBeenCalledTimes(2);
+	});
+
+	test("checkout passes the whole preview through when there is no hosted session", async () => {
+		testState.convexClient.action
+			.mockResolvedValueOnce(ok(freeCustomer))
+			.mockResolvedValueOnce(ok(checkoutPreview));
+
+		const { setupAutumn } = await importSvelteModules();
+		const autumn = setupAutumn({ convexApi: mockAutumnApi });
+
+		await flushPromises();
+
+		// Callers decide between redirecting and confirming, so they need the
+		// preview intact: the product to attach, its prepaid quantities and the
+		// amounts to show. Returning only `url` strands them on a null.
+		await expect(
+			autumn.checkout({ productId: "pro" }, { refetch: false }),
+		).resolves.toEqual(checkoutPreview);
+	});
+
+	test("attach returns its result so a hosted-payment fallback stays reachable", async () => {
+		testState.convexClient.action
+			.mockResolvedValueOnce(ok(freeCustomer))
+			.mockResolvedValueOnce(ok(attachNeedsCheckout));
+
+		const { setupAutumn } = await importSvelteModules();
+		const autumn = setupAutumn({ convexApi: mockAutumnApi });
+
+		await flushPromises();
+
+		// Autumn answers with checkout_url when the stored card could not be
+		// charged. Swallowing it leaves the purchase half-finished and silent.
+		await expect(
+			autumn.attach({ productId: "pro" }, { refetch: false }),
+		).resolves.toEqual(attachNeedsCheckout);
 	});
 
 	test("listProducts, query, getEntity, usage, listEvents, and aggregateEvents do not refetch customer", async () => {

--- a/tests/unit/sveltekit-client.test.ts
+++ b/tests/unit/sveltekit-client.test.ts
@@ -4,6 +4,8 @@ import { flushPromises } from "../helpers/flush.js";
 import { mockAutumnApi } from "../helpers/mock-api.js";
 import { createReactiveServerState } from "../helpers/reactive-state.svelte.js";
 import {
+	attachNeedsCheckout,
+	checkoutPreview,
 	entity,
 	eventListResult,
 	freeCustomer,
@@ -131,6 +133,44 @@ describe("sveltekit client wrapper", () => {
 		);
 
 		expect(invalidate).not.toHaveBeenCalled();
+	});
+
+	test("checkout passes the whole preview through when there is no hosted session", async () => {
+		const invalidate = vi.fn().mockResolvedValue(undefined);
+		testState.convexClient.action.mockResolvedValue(ok(checkoutPreview));
+
+		const { setupAutumn } = await importSvelteKitModules();
+		const autumn = setupAutumn({
+			convexApi: mockAutumnApi,
+			getServerState: () => ({ customer: freeCustomer, _timeFetched: Date.now() }),
+			invalidate,
+		});
+
+		// Callers decide between redirecting and confirming, so they need the
+		// preview intact: the product to attach, its prepaid quantities and the
+		// amounts to show. Returning only `url` strands them on a null.
+		await expect(autumn.checkout({ productId: "pro" })).resolves.toEqual(
+			checkoutPreview,
+		);
+	});
+
+	test("attach returns its result so a hosted-payment fallback stays reachable", async () => {
+		const invalidate = vi.fn().mockResolvedValue(undefined);
+		testState.convexClient.action.mockResolvedValue(ok(attachNeedsCheckout));
+
+		const { setupAutumn } = await importSvelteKitModules();
+		const autumn = setupAutumn({
+			convexApi: mockAutumnApi,
+			getServerState: () => ({ customer: freeCustomer, _timeFetched: Date.now() }),
+			invalidate,
+		});
+
+		// Autumn answers with checkout_url when the stored card could not be
+		// charged. Swallowing it leaves the purchase half-finished and silent.
+		await expect(autumn.attach({ productId: "pro" })).resolves.toEqual(
+			attachNeedsCheckout,
+		);
+		expect(invalidate).toHaveBeenCalledWith("autumn:customer");
 	});
 
 	test("listProducts, query, getEntity, usage, listEvents, aggregateEvents, and billingPortal do not invalidate", async () => {

--- a/tsconfig.contracts.json
+++ b/tsconfig.contracts.json
@@ -1,0 +1,15 @@
+{
+	// The type-level contracts in tests/contracts only mean something if a type
+	// checker actually runs over them. `bun run check` uses svelte-check with
+	// --no-tsconfig, which by design ignores JS/TS files, and Vitest strips
+	// types while transforming. Without this scoped pass, a return type could
+	// silently regress and every job would stay green.
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": false,
+		"declarationMap": false,
+		"sourceMap": false
+	},
+	"include": ["tests/contracts/**/*.ts", "src/lib/svelte/**/*.ts", "src/lib/sveltekit/**/*.ts"]
+}


### PR DESCRIPTION
`checkout()` and `attach()` both dropped information their callers need.

`checkout` was typed `Promise<{ url?: string }>` although it returns the full `CheckoutResult` at runtime. Autumn answers without a hosted Stripe session whenever a purchase can be completed in-app, sending a preview instead — the product, its prepaid quantities, the amounts and whether prorations apply — and none of that was visible through the wrapper. `attach` was worse: it discarded its result entirely, so a `checkout_url`, which means the stored card could not be charged and the customer still has to pay on a hosted page, was unreachable. An app built on this cannot implement Autumn's documented confirmation flow at all; the upgrade button just goes quiet.

Both methods now return their result. `CheckoutResult`, `AttachResult` and `AttachFeatureOptions` are exported from both entry points, with one deliberate deviation from upstream: `url` is widened to `string | null | undefined`, because Autumn declares `string | undefined` while the live API answers `null`, and re-exporting that unchanged would pass the mistake on to every consumer. Runtime behaviour, refetching and invalidation are untouched.

Two things the first round missed. The type-level contracts were decorative: `svelte-check --no-tsconfig` ignores JS/TS files by design and Vitest strips types, so a return type could have regressed behind a green suite. `test:contracts` now runs `tsc` over a scoped config first, verified to fail when `attach` is put back to `Promise<void>`. And the README examples still completed a purchase only for the URL case, which is exactly the gap being fixed; both now show the preview-to-`attach` ending and handle `checkout_url`.

Released as 0.4.0 rather than a patch: `Promise<AttachResult>` is not source-compatible everywhere `Promise<void>` was, and `url` gains `null`. On a 0.x line a minor keeps `^0.3.x` consumers away from the change.

Verified with `bun run check`, `bun run test` (65 passing, including unit tests that fail against the old return values) and `bun run package` with publint clean.